### PR TITLE
Use glob2 to be compatible with python2

### DIFF
--- a/Augmentor/ImageSource.py
+++ b/Augmentor/ImageSource.py
@@ -6,7 +6,7 @@ from builtins import next
 from builtins import str
 from future import standard_library
 standard_library.install_aliases()
-from Augmentor import glob
+import glob2
 from Augmentor import ImageDetails
 from Augmentor import ImageFormat
 from Augmentor import Image
@@ -69,7 +69,7 @@ class ImageSource(object):
         elif os.path.isdir(path_to_scan):
             print("Processing directory")
             for extension in self.file_extension:
-                list_of_files.extend(glob.glob(path_to_scan + '/**/*.' + extension, recursive=True))
+                list_of_files.extend(glob2.glob(path_to_scan + '/**/*.' + extension))
             for file in list_of_files:
                 image = Image.open(file)
                 self.list_of_images.append(ImageDetails.ImageDetails(image, file))

--- a/Augmentor/__init__.py
+++ b/Augmentor/__init__.py
@@ -8,7 +8,7 @@ import os
 from terminaltables import GithubFlavoredMarkdownTable
 from PIL import Image, ImageOps
 import random
-import glob
+import glob2
 from collections import defaultdict
 from fractions import gcd
 from io import BytesIO

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Pillow
 terminaltables
 future
+glob2


### PR DESCRIPTION
glob in python2.7 does not take the second param 'recursive', the recursive process involves some extra code. Instead glob2 is compatible with python2 and 3 (at least tested with python3.3 as stated on the doc), it performs recursive search by default.