### PR TITLE
Add pytorch support in Pipeline class

### DIFF
--- a/Augmentor/Pipeline.py
+++ b/Augmentor/Pipeline.py
@@ -466,6 +466,34 @@ class Pipeline(object):
 
             yield(X, y)
 
+    def torch_transform(self):
+        """
+        Returns the pipeline as a function that can be used with torchvision.
+
+        .. code-block:: python
+
+            >>> import Augmentor
+            >>> import torchvision
+            >>> p = Augmentor.Pipeline()
+            >>> p.rotate(probability=0.7, max_left_rotate=10, max_right_rotate=10)
+            >>> p.zoom(probability=0.5, min_factor=1.1, max_factor=1.5)
+            >>> transforms = torchvision.transforms.Compose([
+            >>>     p.torch_transform(),
+            >>>     torchvision.transforms.ToTensor(),
+            >>> ])
+
+        :return: The pipeline as a function.
+        """
+        def _transform(image):
+            for operation in self.operations:
+                r = round(random.uniform(0, 1), 1)
+                if r <= operation.probability:
+                    image = operation.perform_operation(image)
+
+            return image
+
+        return _transform
+
     def add_operation(self, operation):
         """
         Add an operation directly to the pipeline. Can be used to add custom

--- a/tests/test_torch_transform.py
+++ b/tests/test_torch_transform.py
@@ -1,0 +1,23 @@
+import pytest
+
+# Context
+import numpy as np
+import PIL.Image as Image
+import torchvision
+
+import Augmentor
+
+def test_torch_transform():
+    red = np.zeros([10, 10, 3], np.uint8)
+    red[..., 0] = 255
+    red = Image.fromarray(red)
+
+    g = Augmentor.Operations.Greyscale(1)
+
+    p = Augmentor.Pipeline()
+    p.greyscale(1)
+    transforms = torchvision.transforms.Compose([
+        p.torch_transform()
+    ])
+
+    assert g.perform_operation(red) == transforms(red)


### PR DESCRIPTION
PyTorch comes with a pure-Python image manipulation library called [torchvision](http://pytorch.org/docs/master/torchvision/transforms.html), which currently lacks Augmentor's variety of image transformation operations. This patch is to suggest an addition of a simple method to support torchvision's call-based API, in hope that Augmentor be used in other machine learning frameworks in addition to Keras.

The code is shorter than it sounds. Test attached.