### PR TITLE
Add PyTorch support in Pipeline class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,19 @@ python:
   - "3.5"
   - "3.6"
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install:
+  # Install conda.
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export OPATH="$PATH" && export PATH="$HOME/miniconda/bin:$PATH"
+  - conda create -q -y -n test-environment python=$TRAVIS_PYTHON_VERSION pytest
+  - source activate test-environment
+  # Attempt to install torchvision; on failure, revert back to pre-conda environment.
+  - conda install -q -y torchvision -c soumith || export PATH="$OPATH"
+  - pip install -r requirements.txt
 # command to run tests
 script: py.test -v

--- a/Augmentor/Pipeline.py
+++ b/Augmentor/Pipeline.py
@@ -466,6 +466,34 @@ class Pipeline(object):
 
             yield(X, y)
 
+    def torch_transform(self):
+        """
+        Returns the pipeline as a function that can be used with torchvision.
+
+        .. code-block:: python
+
+            >>> import Augmentor
+            >>> import torchvision
+            >>> p = Augmentor.Pipeline()
+            >>> p.rotate(probability=0.7, max_left_rotate=10, max_right_rotate=10)
+            >>> p.zoom(probability=0.5, min_factor=1.1, max_factor=1.5)
+            >>> transforms = torchvision.transforms.Compose([
+            >>>     p.torch_transform(),
+            >>>     torchvision.transforms.ToTensor(),
+            >>> ])
+
+        :return: The pipeline as a function.
+        """
+        def _transform(image):
+            for operation in self.operations:
+                r = round(random.uniform(0, 1), 1)
+                if r <= operation.probability:
+                    image = operation.perform_operation(image)
+
+            return image
+
+        return _transform
+
     def add_operation(self, operation):
         """
         Add an operation directly to the pipeline. Can be used to add custom

--- a/tests/test_torch_transform.py
+++ b/tests/test_torch_transform.py
@@ -1,0 +1,23 @@
+import pytest
+
+# Context
+import numpy as np
+import PIL.Image as Image
+import torchvision
+
+import Augmentor
+
+def test_torch_transform():
+    red = np.zeros([10, 10, 3], np.uint8)
+    red[..., 0] = 255
+    red = Image.fromarray(red)
+
+    g = Augmentor.Operations.Greyscale(1)
+
+    p = Augmentor.Pipeline()
+    p.greyscale(1)
+    transforms = torchvision.transforms.Compose([
+        p.torch_transform()
+    ])
+
+    assert g.perform_operation(red) == transforms(red)

--- a/tests/test_torch_transform.py
+++ b/tests/test_torch_transform.py
@@ -3,11 +3,12 @@ import pytest
 # Context
 import numpy as np
 import PIL.Image as Image
-import torchvision
 
 import Augmentor
 
 def test_torch_transform():
+    torchvision = pytest.importorskip("torchvision")
+
     red = np.zeros([10, 10, 3], np.uint8)
     red[..., 0] = 255
     red = Image.fromarray(red)
@@ -20,4 +21,5 @@ def test_torch_transform():
         p.torch_transform()
     ])
 
+    assert red != transforms(red)
     assert g.perform_operation(red) == transforms(red)


### PR DESCRIPTION
This is a re-post of pull request #45. Build failure is now fixed, but .travis.yml became messy, for:
- torchvision is not on PyPI, only on Anaconda
- torchvision supports only Python 2.7, 3.5, and 3.6