### PR TITLE
Enable zoom out same size

### DIFF
--- a/Augmentor/Operations.py
+++ b/Augmentor/Operations.py
@@ -1401,7 +1401,11 @@ class Zoom(Operation):
         image_zoomed = image.resize((int(round(image.size[0] * factor)), int(round(image.size[1] * factor))), resample=Image.BICUBIC)
         w_zoomed, h_zoomed = image_zoomed.size
 
-        return image_zoomed.crop(((w_zoomed / 2) - (w / 2), (h_zoomed / 2) - (h / 2), (w_zoomed / 2) + (w / 2), (h_zoomed / 2) + (h / 2)))
+        return image_zoomed.crop((floor((float(w_zoomed) / 2) - (float(w) / 2)),
+                                  floor((float(h_zoomed) / 2) - (float(h) / 2)),
+                                  floor((float(w_zoomed) / 2) + (float(w) / 2)),
+                                  floor((float(h_zoomed) / 2) + (float(h) / 2))))
+
 
         ################################################################################################################
         # Return the centre of the zoomed image, so that it is the same size as the original image

--- a/Augmentor/Pipeline.py
+++ b/Augmentor/Pipeline.py
@@ -913,8 +913,8 @@ class Pipeline(object):
         """
         if not 0 < probability <= 1:
             raise ValueError(Pipeline._probability_error_text)
-        elif min_factor < 1:
-            raise ValueError("The min_factor argument must be greater than 1.")
+        elif min_factor <= 0:
+            raise ValueError("The min_factor argument must be greater than 0.")
         else:
             self.add_operation(Zoom(probability=probability, min_factor=min_factor, max_factor=max_factor))
 


### PR DESCRIPTION
The input for the zoom operation is limited to min_factor>1.
I actually needed to use it for a "zoom out" functionality and simply disabled the input check - then everything worked as expected.
Should this input check even be there? I know for most users adding a black margin for the "zoom out" effect is unwanted, but they can simply only use min_factor>1 so no need to forbid it.

See the issue I opened here:
https://github.com/mdbloice/Augmentor/issues/53#issuecomment-340140842