### PR TITLE
improve skew performance

### DIFF
--- a/Augmentor/Operations.py
+++ b/Augmentor/Operations.py
@@ -402,7 +402,7 @@ class Skew(Operation):
         A = np.matrix(matrix, dtype=np.float)
         B = np.array(original_plane).reshape(8)
 
-        perspective_skew_coefficients_matrix = np.dot(np.linalg.inv(A.T * A) * A.T, B)
+        perspective_skew_coefficients_matrix = np.dot(np.linalg.pinv(A), B)
         perspective_skew_coefficients_matrix = np.array(perspective_skew_coefficients_matrix).reshape(8)
 
         return image.transform(image.size,


### PR DESCRIPTION
Thanks for providing this library! It's easy to use and very useful!

However, I noticed that it slows down our training pipeline a lot. After some profiling I realized that most of the time it spent inversing matrices in `Augmentor/Operations.py:405`.

The code is actually implementing the "Moore-Penrose inverse" [1] which has an optimized implementation in numpy [2]

I checked that the result is the same with
```python
perspective_skew_coefficients_matrix_old = np.dot(np.linalg.inv(A.T * A) * A.T, B)
perspective_skew_coefficients_matrix = np.dot(np.linalg.pinv(A), B)

assert np.allclose(perspective_skew_coefficients_matrix_old, perspective_skew_coefficients_matrix)
```

Performance tests:
- 250 image crops, minimal size 64x64 pixel
- timing with `time` command (using sum of `user` and `sys`, which is more important than `real` when running on multiprocessing and trying to max out CPU)

not optimized: 10.2s
optimized: 0.4s

[1] https://en.wikipedia.org/wiki/Moore%E2%80%93Penrose_inverse#Definition
[2] https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.linalg.pinv.html#numpy.linalg.pinv