### PR TITLE
Allow absolute path as output path name

### DIFF
--- a/Augmentor/Pipeline.py
+++ b/Augmentor/Pipeline.py
@@ -121,9 +121,12 @@ class Pipeline(object):
             if not os.path.exists(ground_truth_directory):
                 raise IOError("The ground truth source directory you specified does not exist.")
 
-        # Get absolute path for output
-        abs_output_directory = os.path.join(source_directory, output_directory)
-
+        # Allow to specity an absolute path for output directory
+        if(not os.path.isabs(output_directory)):
+          abs_output_directory = os.path.join(source_directory, output_directory)
+        else:
+          abs_output_directory = output_directory
+          
         # Scan the directory that user supplied.
         self.augmentor_images, self.class_labels = scan(source_directory, abs_output_directory)
 


### PR DESCRIPTION
Allow an absolute path to be specified as output_file in the Pipeline.
Sometimes can be useful to have augumented files saved in a path completely unrelated to the source_path you read the input_image from.
So just specifying an "absolute" pathname is "/my_output/path" can be enough to do the job with the check I added in the code.
Hope it's something useful for other user too.