### PR TITLE
Fix #96 README quick start guide still using old rotate parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ p = Augmentor.Pipeline("/path/to/images")
 You can then add operations to the Pipeline object `p` as follows:
 
 ```python
-p.rotate(probability=0.7, max_left=10, max_right=10)
+p.rotate(probability=0.7, max_left_rotation=10, max_right_rotation=10)
 p.zoom(probability=0.5, min_factor=1.1, max_factor=1.5)
 ```
 


### PR DESCRIPTION
This pull request simply fixes the Quick Start Guide rotate method parameters to match the current names.