### PR TITLE
fixed torch transform error

### DIFF
--- a/Augmentor/Pipeline.py
+++ b/Augmentor/Pipeline.py
@@ -631,6 +631,8 @@ class Pipeline(object):
                 if r <= operation.probability:
                     image = [image]
                     image = operation.perform_operation(image)
+					if type(image) is list:
+						image = image[0]
 
             return image
 

--- a/Augmentor/Pipeline.py
+++ b/Augmentor/Pipeline.py
@@ -631,8 +631,8 @@ class Pipeline(object):
                 if r <= operation.probability:
                     image = [image]
                     image = operation.perform_operation(image)
-					if type(image) is list:
-						image = image[0]
+                    if type(image) is list:
+                        image = image[0]
 
             return image
 


### PR DESCRIPTION
I tried using the pipeline with torch transforms and have noticed that there was a problem with the image type in the operations for loop - the image was returned as a list, this list has been inserted into another list and then to the transform, which caused an error.
I have added a casting from list to image after every operation in the pipeline, this has solved the problem to my understanding.