### PR TITLE
Update torch_transform and tests

### DIFF
--- a/Augmentor/Pipeline.py
+++ b/Augmentor/Pipeline.py
@@ -627,11 +627,9 @@ class Pipeline(object):
         """
         def _transform(image):
             for operation in self.operations:
-                r = round(random.uniform(0, 1), 1)
-                if r <= operation.probability:
-                    image = [image]
-                    image = operation.perform_operation(image)
-
+                r = random.uniform(0, 1)
+                if r < operation.probability:
+                    image = operation.perform_operation([image])[0]
             return image
 
         return _transform

--- a/tests/test_torch_transform.py
+++ b/tests/test_torch_transform.py
@@ -14,13 +14,21 @@ def test_torch_transform():
     red[..., 0] = 255
     red = Image.fromarray(red)
 
-    g = Augmentor.Operations.Greyscale(1)
-
     p = Augmentor.Pipeline()
-    p.greyscale(1)
+
+    # include multiple transforms to test integration
+    p.greyscale(probability=1)
+    p.zoom(probability=1, min_factor=1.0, max_factor=1.0)
+    p.rotate_random_90(probability=1)
+
     transforms = torchvision.transforms.Compose([
         p.torch_transform()
     ])
 
     assert red != transforms(red)
-    assert g.perform_operation([red]) == transforms(red)
+
+    # assert that all operations were correctly applied
+    result = red
+    for op in p.operations:
+        result = op.perform_operation([result])[0]
+    assert transforms(red) == result


### PR DESCRIPTION
There was a bug in the `torch_transform` function where the image was
being re-enclosed in a list multiple times (the respective methods on
the expected image then failed because the items were instead themselves
lists).

The bug was never caught by the tests because only one transform was
ever performed. The tests have also been updated to now catch this.

(Rounding the random sample was also unnecessary).