### PR TITLE
Add ability to duplicate augmentor_images

### DIFF
--- a/Augmentor/Pipeline.py
+++ b/Augmentor/Pipeline.py
@@ -335,6 +335,9 @@ class Pipeline(object):
 
         if n == 0:
             augmentor_images = self.augmentor_images
+        elif n < 0:
+            n_duplicates = abs(n)
+            augmentor_images = n_duplicates*self.augmentor_images
         else:
             augmentor_images = [random.choice(self.augmentor_images) for _ in range(n)]
 


### PR DESCRIPTION
Instead of just being able to use all of the original images (n=0), this allows cloning the original images (by using a negative number) before applying the transformations.

This is my first time asking for a pull request on GitHub. This is a very small change. When I was using this package in my project I wanted a way to scale my original dataset, but also keep the data even over all the categories. In sample(), you specify the number of samples you would like to generate (the n parameter), but this is stochastic and does not keep the categories even. You can also use n=0 apply transformations on every image in the original dataset, but I wanted multiple transformations on the same image (say I was scaling my dataset 3x). I added a couple lines for the ability to specify negative numbers for n. The absolute value of n is the amount you wish to scale the dataset before applying the transformations.

Again this is my first pull request, please let me know what I did wrong.