### PR TITLE
fixed TypeError

### DIFF
--- a/Augmentor/Pipeline.py
+++ b/Augmentor/Pipeline.py
@@ -808,7 +808,7 @@ class Pipeline(object):
             if image.label_pair is not None:
                 label_count += 1
 
-        if len(label_count) != 0:
+        if label_count != 0:
             label_pairs = sorted(set([x.label_pair for x in self.augmentor_images]))
 
             print("Classes: %s" % len(label_pairs))


### PR DESCRIPTION
Hi, thanks for this amazing library! I've been looking for something like this for a while.

I couldn't get an example to work because of the following error:

```
~/.local/lib/python3.5/site-packages/Augmentor/Pipeline.py in status(self)
    809                 label_count += 1
    810 
--> 811         if len(label_count) != 0:
    812             label_pairs = sorted(set([x.label_pair for x in self.augmentor_images]))
    813 

TypeError: object of type 'int' has no len()
```

Which seemed easy enough to fix.
I must admit that I haven't studied the code in any sort of depth yet, so be sure to let me know if I misunderstood anything.