### PR TITLE
Add padding value for mask

### DIFF
--- a/Augmentor/Operations.py
+++ b/Augmentor/Operations.py
@@ -674,10 +674,20 @@ class RotateStandard(Operation):
             rotation = random_right
 
         def do(image):
-            return image.rotate(rotation, expand=self.expand, resample=Image.BICUBIC, fillcolor=self.fillcolor)
+            return image.rotate(
+                rotation,
+                expand=self.expand,
+                resample=Image.BICUBIC,
+                fillcolor=self.fillcolor,
+            )
 
         def do_mask(mask_image):
-            return mask_image.rotate(rotation, expand=self.expand, resample=Image.BICUBIC, fillcolor=self.mask_fillcolor)
+            return mask_image.rotate(
+                rotation,
+                expand=self.expand,
+                resample=Image.BICUBIC,
+                fillcolor=self.mask_fillcolor,
+            )
 
         augmented_images = []
 

--- a/Augmentor/Operations.py
+++ b/Augmentor/Operations.py
@@ -634,7 +634,15 @@ class RotateStandard(Operation):
     .. seealso:: For 90 degree rotations, see the :class:`Rotate` class.
     """
 
-    def __init__(self, probability, max_left_rotation, max_right_rotation, expand=False, fillcolor=None):
+    def __init__(
+            self,
+            probability,
+            max_left_rotation,
+            max_right_rotation,
+            expand=False,
+            fillcolor=None,
+            mask_fillcolor=None,
+    ):
         """
         Documentation to appear.
         """
@@ -643,6 +651,7 @@ class RotateStandard(Operation):
         self.max_right_rotation = abs(max_right_rotation)  # Ensure always positive
         self.expand = expand
         self.fillcolor = fillcolor
+        self.mask_fillcolor = mask_fillcolor
 
     def perform_operation(self, images):
         """
@@ -652,7 +661,6 @@ class RotateStandard(Operation):
         :return: The transformed image(s) as a list of object(s) of type
          PIL.Image.
         """
-
         random_left = random.randint(self.max_left_rotation, 0)
         random_right = random.randint(0, self.max_right_rotation)
 
@@ -668,10 +676,16 @@ class RotateStandard(Operation):
         def do(image):
             return image.rotate(rotation, expand=self.expand, resample=Image.BICUBIC, fillcolor=self.fillcolor)
 
+        def do_mask(mask_image):
+            return mask_image.rotate(rotation, expand=self.expand, resample=Image.BICUBIC, fillcolor=self.mask_fillcolor)
+
         augmented_images = []
 
-        for image in images:
-            augmented_images.append(do(image))
+        for i, image in enumerate(images):
+            if i == 0:
+                augmented_images.append(do(image))
+            else:
+                augmented_images.append(do_mask(image))
 
         return augmented_images
 

--- a/Augmentor/Pipeline.py
+++ b/Augmentor/Pipeline.py
@@ -962,7 +962,15 @@ class Pipeline(object):
             self.add_operation(RotateRange(probability=probability, max_left_rotation=ceil(max_left_rotation),
                                            max_right_rotation=ceil(max_right_rotation)))
 
-    def rotate_without_crop(self, probability, max_left_rotation, max_right_rotation, expand=False, fillcolor=None):
+    def rotate_without_crop(
+            self,
+            probability,
+            max_left_rotation,
+            max_right_rotation,
+            expand=False,
+            fillcolor=None,
+            mask_fillcolor=None,
+    ):
         """
         Rotate an image without automatically cropping.
 
@@ -991,7 +999,7 @@ class Pipeline(object):
         """
         self.add_operation(RotateStandard(probability=probability, max_left_rotation=ceil(max_left_rotation),
                                           max_right_rotation=ceil(max_right_rotation), expand=expand,
-                                          fillcolor=fillcolor))
+                                          fillcolor=fillcolor, mask_fillcolor=mask_fillcolor))
 
     def flip_top_bottom(self, probability):
         """

--- a/Augmentor/Pipeline.py
+++ b/Augmentor/Pipeline.py
@@ -995,6 +995,10 @@ class Pipeline(object):
          of the input. Default value is None (points filled with black color).
          For example, in case of RGB color scheme simply use `(r, g, b)` tuple
          of int numbers.
+        :param mask_fillcolor: Specify color to fill points outside the boundaries
+         of the ground truth. Default value is None (points filled with black color).
+         For example, in case of RGB color scheme simply use `(r, g, b)` tuple
+         of int numbers.
         :return: None
         """
         self.add_operation(RotateStandard(probability=probability, max_left_rotation=ceil(max_left_rotation),


### PR DESCRIPTION
I have noticed that the image and ground truth are processing in the same way, but this entails difficulties when they have different color schemes. So I made a new do_mask function that handles ground_truth images.

Example of usage:
```python   
    p.rotate_without_crop(
        probability=0.7,
        max_left_rotation=10,
        max_right_rotation=10,
        fillcolor=(255, 255, 255),  # will apply to image
        mask_fillcolor=127,  # will apply to grayscale ground truth 
    )
```