### PR TITLE
add direction support to shear

### DIFF
--- a/Augmentor/Operations.py
+++ b/Augmentor/Operations.py
@@ -1154,7 +1154,7 @@ class Shear(Operation):
 
     For sample code with image examples see :ref:`shearing`.
     """
-    def __init__(self, probability, max_shear_left, max_shear_right):
+    def __init__(self, probability, max_shear_left, max_shear_right, directions=['x','y']):
         """
         The shearing is randomised in magnitude, from 0 to the
         :attr:`max_shear_left` or 0 to :attr:`max_shear_right` where the
@@ -1171,6 +1171,7 @@ class Shear(Operation):
         :type max_shear_right: Integer
         """
         Operation.__init__(self, probability)
+        self.directions = directions
         self.max_shear_left = max_shear_left
         self.max_shear_right = max_shear_right
 
@@ -1227,7 +1228,7 @@ class Shear(Operation):
         # any of the affine transformation matrices, seen here:
         # https://en.wikipedia.org/wiki/Transformation_matrix#/media/File:2D_affine_transformation_matrix.svg
 
-        directions = ["x", "y"]
+        directions = self.directions # ["x", "y"]
         direction = random.choice(directions)
 
         def do(image):

--- a/Augmentor/Pipeline.py
+++ b/Augmentor/Pipeline.py
@@ -1484,7 +1484,7 @@ class Pipeline(object):
                                     skew_type="RANDOM",
                                     magnitude=magnitude))
 
-    def shear(self, probability, max_shear_left, max_shear_right):
+    def shear(self, probability, max_shear_left, max_shear_right, directions=['x','y']):
         """
         Shear the image by a specified number of degrees.
 
@@ -1498,6 +1498,8 @@ class Pipeline(object):
          Cannot be larger than 25 degrees.
         :param max_shear_right: The max number of degrees to shear to the
          right. Cannot be larger than 25 degrees.
+        :param directions: The directions to shear along.
+         Has to be one of ['x','y'], ['x'], and ['y']. Defaults to ['x','y']
         :return: None
         """
         if not 0 < probability <= 1:
@@ -1509,7 +1511,8 @@ class Pipeline(object):
         else:
             self.add_operation(Shear(probability=probability,
                                      max_shear_left=max_shear_left,
-                                     max_shear_right=max_shear_right))
+                                     max_shear_right=max_shear_right,
+                                     directions=directions))
 
     def greyscale(self, probability):
         """


### PR DESCRIPTION
Tasks like OCR need shear in `x` direction only.
This pull request adds an ability to add shear only in `x`, or `y` or both directions while creating `pipeline.shear`