### PR TITLE
Change type aliases in two places; np.float -> float, np.int -> int.

### DIFF
--- a/Augmentor/Operations.py
+++ b/Augmentor/Operations.py
@@ -604,7 +604,7 @@ class Skew(Operation):
             matrix.append([p1[0], p1[1], 1, 0, 0, 0, -p2[0] * p1[0], -p2[0] * p1[1]])
             matrix.append([0, 0, 0, p1[0], p1[1], 1, -p2[1] * p1[0], -p2[1] * p1[1]])
 
-        A = np.matrix(matrix, dtype=np.float)
+        A = np.matrix(matrix, dtype=float)
         B = np.array(original_plane).reshape(8)
 
         perspective_skew_coefficients_matrix = np.dot(np.linalg.pinv(A), B)

--- a/notebooks/Per_Class_Augmentation_Strategy.ipynb
+++ b/notebooks/Per_Class_Augmentation_Strategy.ipynb
@@ -338,7 +338,7 @@
     "pipeline_containers = []\n",
     "\n",
     "for label, pipeline in pipelines.items():\n",
-    "    label_categorical = np.zeros(len(pipelines), dtype=np.int)\n",
+    "    label_categorical = np.zeros(len(pipelines), dtype=int)\n",
     "    label_categorical[integer_labels[label]] = 1\n",
     "    pipeline_containers.append(PipelineContainer(label, \n",
     "                                                 integer_labels[label], \n",


### PR DESCRIPTION
These aliases were removed in numpy 1.20. https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated. I believe these changes will be backwards compatible with older versions of numpy too.

Fixes #250 