### PR TITLE
Update setup.cfg key for setuptools deprecation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 universal=1
 
 [metadata]
-license_file = LICENSE.md
+license_files = LICENSE.md


### PR DESCRIPTION
Got while installing with `pip`
```
!!

        ********************************************************************************
        The license_file parameter is deprecated, use license_files instead.

        By 2023-Oct-30, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
        ********************************************************************************

!!

```

https://github.com/pypa/setuptools/pull/4066