### PR TITLE
Modify cropping boundaries after rotation to preserve image ratio

### DIFF
--- a/Augmentor/Operations.py
+++ b/Augmentor/Operations.py
@@ -832,11 +832,11 @@ class RotateRange(Operation):
             angle_b_sin = math.sin(angle_b_rad)
 
             # Find the maximum area of the rectangle that could be cropped
-            E = (math.sin(angle_a_rad)) / (math.sin(angle_b_rad)) * \
-                (Y - X * (math.sin(angle_a_rad) / math.sin(angle_b_rad)))
-            E = E / 1 - (math.sin(angle_a_rad) ** 2 / math.sin(angle_b_rad) ** 2)
-            B = X - E
-            A = (math.sin(angle_a_rad) / math.sin(angle_b_rad)) * B
+            M = y / math.cos(angle_a_rad)
+            x_p = M / (math.tan(angle_a_rad) + y / x)
+            y_p = x_p * y / x
+            E = (X - x_p) / 2
+            A = (Y - y_p) / 2
 
             # Crop this area from the rotated image
             # image = image.crop((E, A, X - E, Y - A))


### PR DESCRIPTION
After getting an exception when trying to rotate an image with unusual dimensions (470x109) by 15 degrees using RotateRange, I notice that the crop operation at the end of this operation does not seem to preserve the aspect ratio of the image, as it is computed solely from the dimensions (X,Y) of the rotated image.
After a bit of trigonometry, I propose a slight modification for the computation of the cropped region as follows

![crop_rotate](https://github.com/mdbloice/Augmentor/assets/65592546/f43dbdc4-434a-4b5c-9ac9-7cb8eb418f05)

Basically, for a rotation of angle $a$, the value of $M$ (red segment) is computed as $M=\frac{y}{2\times cos(a)}$. Then, knowing that $M = x' \times tan(a) + x' \times tan(c) = x' \times tan(a) + x' \times \frac{y}{x} = x'\times (tan(a)+ \frac{y}{x})$, it follows that $x' = \dfrac{M}{tan(a)+ \frac{y}{x}}$ and $y'=x'\times y/x$ (to preserve aspect ratio).

With this modified code, I seem to obtain better rotated images, see below:

Original image:
![Blue_Grosbeak_0014_36708](https://github.com/mdbloice/Augmentor/assets/65592546/233639a8-cdcb-499b-82f0-47fa030e3ff1)

After rotation (15 degrees) with the original code:
![test_original_Blue_Grosbeak_0014_36708_original_code](https://github.com/mdbloice/Augmentor/assets/65592546/999aaae5-b1d0-4f12-8ce4-7850e7fca187)

With the modified code:
![test_original_Blue_Grosbeak_0014_36708_modified_code](https://github.com/mdbloice/Augmentor/assets/65592546/a3652cb8-9a7d-49ed-afeb-2b45edc536a8)

Furthermore, the code no longer throws an exception when processing images with weird aspect ratios (eg. 470x109). Note however that this formula highly depends on the ability of the `rotate` operation to preserve the right angles of the original image inside the rotated one.

